### PR TITLE
feat: add rounded corners to media cards

### DIFF
--- a/src/components/media-card/media-card.ts
+++ b/src/components/media-card/media-card.ts
@@ -20,6 +20,7 @@ export default class MediaCard extends HTMLElement {
       case 'image':
         tag = `
           <img
+            class="rounded-md"
             height="${height}"
             width="${width}"
             src="${cloudinaryAssetUrl}f_auto/${encodeURIComponent(publicId)}"
@@ -31,6 +32,7 @@ export default class MediaCard extends HTMLElement {
       case 'video':
         tag = `
           <video
+            class="rounded-md"
             controls
             loading="lazy"
           >


### PR DESCRIPTION
**BEFORE** (you can see the image and border are not flush)
<img width="853" height="497" alt="Screenshot 2025-10-06 at 2 07 29 PM" src="https://github.com/user-attachments/assets/6ee6cc4d-24fd-4852-b82f-4da1f78312e7" />

**AFTER**
<img width="845" height="505" alt="Screenshot 2025-10-06 at 2 07 44 PM" src="https://github.com/user-attachments/assets/245fe46d-a531-4fc7-b03c-cb5786b87055" />
